### PR TITLE
Alb addEntriesToAcl() bug

### DIFF
--- a/src/Alb/V20200616/AlbApiResolver.php
+++ b/src/Alb/V20200616/AlbApiResolver.php
@@ -106,10 +106,28 @@ class Rpc extends \AlibabaCloud\Client\Resolver\Rpc
  * @method string getDryRun()
  * @method $this withDryRun($value)
  * @method string getAclEntries()
- * @method $this withAclEntries($value)
  */
 class AddEntriesToAcl extends Rpc
 {
+    /**
+     * @param array $aclEntries
+     *
+     * @return $this
+     */
+    public function withAclEntries(array $aclEntries)
+    {
+        $this->data['AclEntries'] = $aclEntries;
+        foreach ($aclEntries as $depth1 => $depth1Value) {
+            if(isset($depth1Value['Entry'])){
+                $this->options['query']['AclEntries.' . ($depth1 + 1) . '.Entry'] = $depth1Value['Entry'];
+            }
+            if(isset($depth1Value['EntryDescription'])){
+                $this->options['query']['AclEntries.' . ($depth1 + 1) . '.EntryDescription'] = $depth1Value['EntryDescription'];
+            }
+        }
+
+        return $this;
+    }
 }
 
 /**


### PR DESCRIPTION
修复Alb的addEntriesToAcl调用报错。

修复前如下调用时：
```
Alb::v20200616()->addEntriesToAcl()
    ->withAclId("xxx")
    ->withAclEntries([
        [
            "Entry" => "xxx",
            "Description" => "xxx"
        ]
    ]);
```
报错：
```
urlencode() expects parameter 1 to be string, array given
```